### PR TITLE
Fix loading multiple chunks in memory when retrieving a file content size

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 /.gitignore export-ignore
 /phpunit.xml.dist export-ignore
 /tests export-ignore
+/samples export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- `Innmind\Filesystem\File\Content::ofChunks()->size()` no longer load more than one chunk size in memory
+
 ## 7.5.0 - 2024-03-16
 
 ### Changed

--- a/proofs/file/content.php
+++ b/proofs/file/content.php
@@ -246,7 +246,7 @@ return static function() {
             $atPath = Model::atPath(
                 $capabilities->readable(),
                 $io,
-                Path::of('fixtures/sample.pdf'),
+                Path::of('samples/sample.pdf'),
             );
             $content = Model::ofChunks($atPath->chunks());
 

--- a/src/File/Content/Chunks.php
+++ b/src/File/Content/Chunks.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace Innmind\Filesystem\File\Content;
 
+use Innmind\Stream\Stream\Size;
 use Innmind\Immutable\{
     Sequence,
     SideEffect,
@@ -81,7 +82,16 @@ final class Chunks implements Implementation
 
     public function size(): Maybe
     {
-        return $this->content()->size();
+        return Maybe::just(
+            $this
+                ->chunks
+                ->map(static fn($chunk) => $chunk->toEncoding(Str\Encoding::ascii))
+                ->map(static fn($chunk) => $chunk->length())
+                ->reduce(
+                    0,
+                    static fn(int $total, int $chunk) => $total + $chunk,
+                ),
+        )->map(static fn($size) => new Size($size));
     }
 
     public function toString(): string


### PR DESCRIPTION
## Problem

When creating a file content by chunks (via `Content::ofChunks()`) and retrieving its size (via the `->size()` method then depending on the content of the chunks it may load in memory multiple chunks (or even the whole file).

This is due to the fact that `Content\Chunks::size()` use the implementation of `Content\Lines::size()` to compute the size. But in order to use it it recompose the chunks into lines (by separating chunks by the `\n` char). But if the chunks are binary content then this char is never found and we end up with the whole file as a single line.

## Fix

`Content\Chunks::size()` now computes the length of each chunk and then adds them up.